### PR TITLE
fix: update provisioning profile to dust-distribution-2026

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -374,7 +374,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = nexus.concepts.dust;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "dust-distribution";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "dust-distribution-2026";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -400,7 +400,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = nexus.concepts.dust;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "dust-distribution";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "dust-distribution-2026";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ios/archive.plist
+++ b/ios/archive.plist
@@ -7,7 +7,7 @@
 <key>provisioningProfiles</key>
 <dict>
     <key>nexus.concepts.dust</key>
-    <string>dust-distribution</string>
+    <string>dust-distribution-2026</string>
 </dict>
 </dict>
 </plist>


### PR DESCRIPTION
This pull request updates the provisioning profile used for iOS builds of the app to a new profile named `dust-distribution-2026`. This change ensures that the app is signed with the correct, updated provisioning profile for future distributions.

Provisioning profile update:

* Updated the `PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]` setting in `App.xcodeproj/project.pbxproj` to use `dust-distribution-2026` instead of `dust-distribution`. [[1]](diffhunk://#diff-daf8b4afd54ea846a9a196d9d428c052957b96c0f10520c88ee07c018194321fL377-R377) [[2]](diffhunk://#diff-daf8b4afd54ea846a9a196d9d428c052957b96c0f10520c88ee07c018194321fL403-R403)
* Updated the `provisioningProfiles` entry for `nexus.concepts.dust` in `archive.plist` to use `dust-distribution-2026`.