### PR TITLE
Add barcode scanning and QR code dependencies

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation project(':capacitor-community-keep-awake')
     implementation project(':capacitor-app')
     implementation project(':capacitor-app-launcher')
+    implementation project(':capacitor-barcode-scanner')
     implementation project(':capacitor-browser')
     implementation project(':capacitor-filesystem')
     implementation project(':capacitor-geolocation')

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -14,6 +14,9 @@ project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/
 include ':capacitor-app-launcher'
 project(':capacitor-app-launcher').projectDir = new File('../node_modules/@capacitor/app-launcher/android')
 
+include ':capacitor-barcode-scanner'
+project(':capacitor-barcode-scanner').projectDir = new File('../node_modules/@capacitor/barcode-scanner/android')
+
 include ':capacitor-browser'
 project(':capacitor-browser').projectDir = new File('../node_modules/@capacitor/browser/android')
 

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -1,5 +1,5 @@
 ext {
-    minSdkVersion = 23
+    minSdkVersion = 26
     compileSdkVersion = 36
     targetSdkVersion = 36
     androidxActivityVersion = '1.8.0'

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "@capacitor/android": "8.4.2",
         "@capacitor/app": "8.1.1",
         "@capacitor/app-launcher": "8.0.1",
+        "@capacitor/barcode-scanner": "^3.1.1",
         "@capacitor/browser": "8.0.4",
         "@capacitor/core": "8.4.2",
         "@capacitor/filesystem": "8.1.2",
@@ -41,6 +42,7 @@
         "@sentry/angular": "9.46.0",
         "@sentry/capacitor": "^2.4.1",
         "@sentry/cli": "^2.58.6",
+        "@types/qrcode": "^1.5.6",
         "@webnativellc/capacitor-filesharer": "7.1.0",
         "@webnativellc/capacitor-navigation-bar": "^7.1.0",
         "@webnativellc/capacitor-print-webview": "7.1.0",
@@ -50,6 +52,7 @@
         "idb-keyval": "6.2.6",
         "ionicons": "^7.4.0",
         "ngxtension": "7.0.2",
+        "qrcode": "^1.5.4",
         "rxjs": "~7.8.2",
         "three": "0.185.1",
         "tslib": "^2.8.1",
@@ -341,6 +344,8 @@
     "@capacitor/app": ["@capacitor/app@8.1.1", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-xM2ZTX5jK60tFtmjsmJv+Cdj1Qsb6NcavkqmdEnCPQBeya9oKhamZJxYOnQNj1ZvcJM7sWfG6BEtSLx42pisbA=="],
 
     "@capacitor/app-launcher": ["@capacitor/app-launcher@8.0.1", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-23D8zi74sn7kxvISix8qYwgqdxGJN+4NImcNGvHen98LB1zb4eZfkJvFvp7pwntxGw4OjIE7yuf4wbzZxQHpog=="],
+
+    "@capacitor/barcode-scanner": ["@capacitor/barcode-scanner@3.1.1", "", { "dependencies": { "html5-qrcode": "2.3.8" }, "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-IftToRn2YTirzw2K8nkp+p7Mcq41vwcZyqcSYLUeyMbznJS2IbEj1snbRIcTXa+iSuAU6zKY7tNXzwDqyzcx+Q=="],
 
     "@capacitor/browser": ["@capacitor/browser@8.0.4", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-ORZ4u/y+7aMuu6yVuk6SP529fUZyqcbnuHB1q5McpA3o2SYfVoi28iB8rsQjI2ad1qlKJd29ZUuGtspXLBDlWg=="],
 
@@ -994,6 +999,8 @@
 
     "@types/node": ["@types/node@22.13.10", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw=="],
 
+    "@types/qrcode": ["@types/qrcode@1.5.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw=="],
+
     "@types/qs": ["@types/qs@6.14.0", "", {}, "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ=="],
 
     "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
@@ -1214,6 +1221,8 @@
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
+    "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+
     "caniuse-lite": ["caniuse-lite@1.0.30001809", "", {}, "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ=="],
 
     "capacitor-plugin-safe-area": ["capacitor-plugin-safe-area@4.0.0", "", { "peerDependencies": { "@capacitor/core": ">=7.0.0" } }, "sha512-5VHT4wG2TlwHtyy3zKrAjKwgJQgC3KeMfRW1bc8abTETLYNLxb85zvfpA0QFE59BxbtYHD57GvXKJuUPgEHl3g=="],
@@ -1310,6 +1319,8 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
+
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
@@ -1331,6 +1342,8 @@
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
+
+    "dijkstrajs": ["dijkstrajs@1.0.3", "", {}, "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="],
 
     "dns-packet": ["dns-packet@5.6.1", "", { "dependencies": { "@leichtgewicht/ip-codec": "^2.0.1" } }, "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw=="],
 
@@ -1571,6 +1584,8 @@
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
     "html-entities": ["html-entities@2.6.0", "", {}, "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ=="],
+
+    "html5-qrcode": ["html5-qrcode@2.3.8", "", {}, "sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ=="],
 
     "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
@@ -1946,6 +1961,8 @@
 
     "p-retry": ["p-retry@6.2.1", "", { "dependencies": { "@types/retry": "0.12.2", "is-network-error": "^1.0.0", "retry": "^0.13.1" } }, "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ=="],
 
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
@@ -1993,6 +2010,8 @@
     "pkijs": ["pkijs@3.4.0", "", { "dependencies": { "@noble/hashes": "1.4.0", "asn1js": "^3.0.6", "bytestreamjs": "^2.0.1", "pvtsutils": "^1.3.6", "pvutils": "^1.1.3", "tslib": "^2.8.1" } }, "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw=="],
 
     "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
+
+    "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -2044,6 +2063,8 @@
 
     "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
 
+    "qrcode": ["qrcode@1.5.4", "", { "dependencies": { "dijkstrajs": "^1.0.1", "pngjs": "^5.0.0", "yargs": "^15.3.1" }, "bin": { "qrcode": "bin/qrcode" } }, "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg=="],
+
     "qs": ["qs@6.14.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
@@ -2074,7 +2095,11 @@
 
     "regjsparser": ["regjsparser@0.13.0", "", { "dependencies": { "jsesc": "~3.1.0" }, "bin": { "regjsparser": "bin/parser" } }, "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q=="],
 
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "require-main-filename": ["require-main-filename@2.0.0", "", {}, "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="],
 
     "requires-port": ["requires-port@1.0.0", "", {}, "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="],
 
@@ -2143,6 +2168,8 @@
     "serve-index": ["serve-index@1.9.2", "", { "dependencies": { "accepts": "~1.3.8", "batch": "0.6.1", "debug": "2.6.9", "escape-html": "~1.0.3", "http-errors": "~1.8.0", "mime-types": "~2.1.35", "parseurl": "~1.3.3" } }, "sha512-KDj11HScOaLmrPxl70KYNW1PksP4Nb/CLL2yvC+Qd2kHMPEEpfc4Re2e4FOay+bC/+XQl/7zAcWON3JVo5v3KQ=="],
 
     "serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
+
+    "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
@@ -2379,6 +2406,8 @@
     "which-builtin-type": ["which-builtin-type@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "function.prototype.name": "^1.1.6", "has-tostringtag": "^1.0.2", "is-async-function": "^2.0.0", "is-date-object": "^1.1.0", "is-finalizationregistry": "^1.1.0", "is-generator-function": "^1.0.10", "is-regex": "^1.2.1", "is-weakref": "^1.0.2", "isarray": "^2.0.5", "which-boxed-primitive": "^1.1.0", "which-collection": "^1.0.2", "which-typed-array": "^1.1.16" } }, "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q=="],
 
     "which-collection": ["which-collection@1.0.2", "", { "dependencies": { "is-map": "^2.0.3", "is-set": "^2.0.3", "is-weakmap": "^2.0.2", "is-weakset": "^2.0.3" } }, "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw=="],
+
+    "which-module": ["which-module@2.0.1", "", {}, "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="],
 
     "which-typed-array": ["which-typed-array@1.1.20", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg=="],
 
@@ -2681,6 +2710,8 @@
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "proxy-addr/ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 
     "raw-body/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -3016,6 +3047,16 @@
 
     "parse-json/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
+    "qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
+
+    "qrcode/yargs/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "qrcode/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
+
+    "qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
+
     "resolve-url-loader/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
@@ -3278,6 +3319,10 @@
 
     "log-update/wrap-ansi/string-width/get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
 
+    "qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "qrcode/yargs/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
     "webpack-dev-server/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "webpack-dev-server/open/wsl-utils/is-wsl": ["is-wsl@3.1.0", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw=="],
@@ -3330,8 +3375,12 @@
 
     "lint-staged/listr2/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
+    "qrcode/yargs/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
     "lint-staged/listr2/cli-truncate/slice-ansi/is-fullwidth-code-point/get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
 
     "lint-staged/listr2/cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "qrcode/yargs/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
   }
 }

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -31,6 +31,8 @@
     </array>
     <key>LSRequiresIPhoneOS</key>
     <true/>
+    <key>NSCameraUsageDescription</key>
+    <string>Scan QR codes to import favorite lists</string>
     <key>NSLocationWhenInUseUsageDescription</key>
     <string>Shows where you are on the map</string>
     <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -15,6 +15,7 @@ def capacitor_pods
   pod 'CapacitorCommunityKeepAwake', :path => '../../node_modules/@capacitor-community/keep-awake'
   pod 'CapacitorApp', :path => '../../node_modules/@capacitor/app'
   pod 'CapacitorAppLauncher', :path => '../../node_modules/@capacitor/app-launcher'
+  pod 'CapacitorBarcodeScanner', :path => '../../node_modules/@capacitor/barcode-scanner'
   pod 'CapacitorBrowser', :path => '../../node_modules/@capacitor/browser'
   pod 'CapacitorFilesystem', :path => '../../node_modules/@capacitor/filesystem'
   pod 'CapacitorGeolocation', :path => '../../node_modules/@capacitor/geolocation'

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -5,6 +5,9 @@ PODS:
     - Capacitor
   - CapacitorAppLauncher (8.0.1):
     - Capacitor
+  - CapacitorBarcodeScanner (3.1.1):
+    - Capacitor
+    - OSBarcodeLib (= 2.2.0)
   - CapacitorBrowser (8.0.4):
     - Capacitor
   - CapacitorCommunityInAppReview (8.0.0):
@@ -100,6 +103,7 @@ PODS:
     - nanopb/encode (= 3.30910.0)
   - nanopb/decode (3.30910.0)
   - nanopb/encode (3.30910.0)
+  - OSBarcodeLib (2.2.0)
   - PromisesObjC (2.4.0)
   - Sentry/HybridSDK (8.56.2)
   - SentryCapacitor (2.4.1):
@@ -116,6 +120,7 @@ DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
   - "CapacitorApp (from `../../node_modules/@capacitor/app`)"
   - "CapacitorAppLauncher (from `../../node_modules/@capacitor/app-launcher`)"
+  - "CapacitorBarcodeScanner (from `../../node_modules/@capacitor/barcode-scanner`)"
   - "CapacitorBrowser (from `../../node_modules/@capacitor/browser`)"
   - "CapacitorCommunityInAppReview (from `../../node_modules/@capacitor-community/in-app-review`)"
   - "CapacitorCommunityKeepAwake (from `../../node_modules/@capacitor-community/keep-awake`)"
@@ -153,6 +158,7 @@ SPEC REPOS:
     - IONFilesystemLib
     - IONGeolocationLib
     - nanopb
+    - OSBarcodeLib
     - PromisesObjC
     - Sentry
 
@@ -163,6 +169,8 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/app"
   CapacitorAppLauncher:
     :path: "../../node_modules/@capacitor/app-launcher"
+  CapacitorBarcodeScanner:
+    :path: "../../node_modules/@capacitor/barcode-scanner"
   CapacitorBrowser:
     :path: "../../node_modules/@capacitor/browser"
   CapacitorCommunityInAppReview:
@@ -216,6 +224,7 @@ SPEC CHECKSUMS:
   Capacitor: 52f999235b8bd6a7d01694753f4f4d54d182e3a3
   CapacitorApp: 305bd13c44f6f9d164e2ee66a4faa956ed8c0e06
   CapacitorAppLauncher: 43949ccc5aaa5139a1ebe27a98c0a4d76c883fa7
+  CapacitorBarcodeScanner: 735028a8496e205c61e89634918b6b42f429e2bb
   CapacitorBrowser: 752e0208aa07c7aa63d1f7cde895a3e9519b2656
   CapacitorCommunityInAppReview: 4492bdd34aad4d27ed87949376022cc93b294ea1
   CapacitorCommunityKeepAwake: d41922812644562e94a79acaf7f41e6d9413af8c
@@ -245,6 +254,7 @@ SPEC CHECKSUMS:
   IONFilesystemLib: 21a63377696b2d8fab5632ecfb7d2ac67bddb68a
   IONGeolocationLib: 6a7b6f76063fb1b01cfb14fae7d0f526e3c9b271
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
+  OSBarcodeLib: aa520d51576362d0dfea290b82653e31df1a6fc4
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   Sentry: b53951377b78e21a734f5dc8318e333dbfc682d7
   SentryCapacitor: 84549a1440a7f58a336ed3175db0f067d571cd5b
@@ -252,6 +262,6 @@ SPEC CHECKSUMS:
   WebnativellcCapacitorNavigationBar: d6dc1402911a5110d771614a9818387947646472
   WebnativellcCapacitorPrintWebview: ac04ee3fcdc1706b053542b935993709730b7898
 
-PODFILE CHECKSUM: 20678badee4cbdf6fb9cba25bb90fcde4eb4a370
+PODFILE CHECKSUM: 3ab124fa10d8ee89827abca62649b0532d273085
 
 COCOAPODS: 1.16.2

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@capacitor/android": "8.4.2",
     "@capacitor/app": "8.1.1",
     "@capacitor/app-launcher": "8.0.1",
+    "@capacitor/barcode-scanner": "^3.1.1",
     "@capacitor/browser": "8.0.4",
     "@capacitor/core": "8.4.2",
     "@capacitor/filesystem": "8.1.2",
@@ -63,6 +64,7 @@
     "@sentry/angular": "9.46.0",
     "@sentry/capacitor": "^2.4.1",
     "@sentry/cli": "^2.58.6",
+    "@types/qrcode": "^1.5.6",
     "@webnativellc/capacitor-filesharer": "7.1.0",
     "@webnativellc/capacitor-navigation-bar": "^7.1.0",
     "@webnativellc/capacitor-print-webview": "7.1.0",
@@ -72,6 +74,7 @@
     "idb-keyval": "6.2.6",
     "ionicons": "^7.4.0",
     "ngxtension": "7.0.2",
+    "qrcode": "^1.5.4",
     "rxjs": "~7.8.2",
     "three": "0.185.1",
     "tslib": "^2.8.1"

--- a/src/app/data/api.service.ts
+++ b/src/app/data/api.service.ts
@@ -32,7 +32,7 @@ import { getCachedImage } from './cache-store';
 import { distance } from '../map/map.utils';
 import { liveBurnDataset } from '../broadcast/utils';
 
-export type DownloadResult = 'success' | 'error' | 'already-updated';
+export type DownloadResult = 'success' | 'partial' | 'error' | 'already-updated';
 
 interface Version {
   version: string;
@@ -418,15 +418,23 @@ export class ApiService {
       `events=${rEvents.status} art=${rArt.status} camps=${rCamps.status} pins=${rPins.status} links=${rLinks.status} map=${rMap.status} geo=${rGeo.status} restrooms=${rRestrooms.status} ice=${rIce.status} medical=${rMedical.status} rsl=${rRSL.status}`,
     );
     let uri: string | undefined = undefined;
+    let mapFailed = false;
     if (map) {
       const ext = map.filename ? map.filename.split('.').pop() : 'svg';
       if (map.filename) {
-        console.info(`download.map ${map.filename} ext=${ext}`);
-        uri = await this.dbService.getLiveBinary(dataset, map.filename, currentVersion);
-        console.info(`download.map uri=${uri}`);
-        downloadSignal.set({ status: `${selected.title}  Map`, firstDownload: myRevision === undefined });
-        uri = await getCachedImage(uri);
-        console.info(`download.map completed`);
+        try {
+          console.info(`download.map ${map.filename} ext=${ext}`);
+          uri = await this.dbService.getLiveBinary(dataset, map.filename, currentVersion);
+          console.info(`download.map uri=${uri}`);
+          downloadSignal.set({ status: `${selected.title}  Map`, firstDownload: myRevision === undefined });
+          uri = await getCachedImage(uri);
+          console.info(`download.map completed`);
+        } catch (err) {
+          // A network issue fetching the map should not abort the launch: continue with any previously cached map
+          console.error(`Download of map ${map.filename} failed`, err);
+          mapFailed = true;
+          uri = undefined;
+        }
       }
     }
 
@@ -440,10 +448,13 @@ export class ApiService {
 
     await this.dbService.writeData(dataset, Names.revision, revision);
     await this.dbService.writeData(dataset, Names.version, { version: await this.getVersion() });
-    map.uri = uri;
+    // Only overwrite the stored map uri when a fresh one was cached: keep any previously cached map on failure
+    if (uri) {
+      map.uri = uri;
+    }
     await this.dbService.writeData(dataset, Names.map, map);
 
     downloadSignal.set({ status: '', firstDownload: false });
-    return 'success';
+    return mapFailed ? 'partial' : 'success';
   }
 }

--- a/src/app/favs/favs.page.html
+++ b/src/app/favs/favs.page.html
@@ -25,9 +25,13 @@
                   <ion-icon name="share-outline" slot="start"></ion-icon>
                   <ion-label>Share Favorites</ion-label>
                 </ion-item>
-                <ion-item detail="false" aria-label="Get Favorites" button (click)="getFavorites()">
+                <ion-item detail="false" aria-label="Scan Favorites" button (click)="scanFavorites()">
+                  <ion-icon name="qr-code-outline" slot="start"></ion-icon>
+                  <ion-label>Scan Favorites</ion-label>
+                </ion-item>
+                <ion-item detail="false" aria-label="Enter Favorite ID" button (click)="getFavorites()">
                   <ion-icon name="download-outline" slot="start"></ion-icon>
-                  <ion-label>Get Favorites</ion-label>
+                  <ion-label>Enter ID</ion-label>
                 </ion-item>
                 <ion-item detail="false" aria-label="Clear Favorites" button (click)="clearFavs()">
                   <ion-icon name="trash-outline" slot="start"></ion-icon>
@@ -77,8 +81,8 @@
   @if (vm.noFavorites) {
   <div class="center pad-sides">
     <ion-text class="large" color="medium"
-      >Tap the <ion-icon [src]="'assets/icon/star.svg'"></ion-icon> icon on Events, Theme Camps and Art to add them
-      to your favorites</ion-text
+      >Tap the <ion-icon [src]="'assets/icon/star.svg'"></ion-icon> icon on Events, Theme Camps and Art to add them to
+      your favorites</ion-text
     >
   </div>
   } @for (event of vm.events; track eventsTrackBy($index, event)) {

--- a/src/app/favs/favs.page.ts
+++ b/src/app/favs/favs.page.ts
@@ -41,7 +41,17 @@ import { SearchComponent } from '../search/search.component';
 import { distance, formatDistanceMiles, toMapPoint } from '../map/map.utils';
 import { GeoService } from '../geolocation/geo.service';
 import { addIcons } from 'ionicons';
-import { star, starOutline, mapOutline, printOutline, calendarOutline, trashOutline, shareOutline, downloadOutline } from 'ionicons/icons';
+import {
+  star,
+  starOutline,
+  mapOutline,
+  printOutline,
+  calendarOutline,
+  trashOutline,
+  shareOutline,
+  downloadOutline,
+  qrCodeOutline,
+} from 'ionicons/icons';
 import { CalendarService } from '../calendar.service';
 import { ToastController, AlertController } from '@ionic/angular';
 import { MessageComponent } from '../message/message.component';
@@ -151,7 +161,17 @@ export class FavsPage implements OnInit {
   isPopoverOpen = false;
 
   constructor() {
-    addIcons({ printOutline, calendarOutline, mapOutline, star, starOutline, trashOutline, shareOutline, downloadOutline });
+    addIcons({
+      printOutline,
+      calendarOutline,
+      mapOutline,
+      star,
+      starOutline,
+      trashOutline,
+      shareOutline,
+      downloadOutline,
+      qrCodeOutline,
+    });
     effect(async () => {
       this.fav.changed();
       await this.update();
@@ -223,7 +243,15 @@ export class FavsPage implements OnInit {
     await modal.present();
   }
 
+  async scanFavorites() {
+    await this.openGetFavorites('scan');
+  }
+
   async getFavorites() {
+    await this.openGetFavorites('manual');
+  }
+
+  private async openGetFavorites(mode: 'scan' | 'manual') {
     this.isPopoverOpen = false;
 
     const networkStatus = await Network.getStatus();
@@ -240,6 +268,7 @@ export class FavsPage implements OnInit {
     const e: any = document.getElementById('my-outlet');
     const modal = await this.modalCtrl.create({
       component: GetFavoritesComponent,
+      componentProps: { mode },
       presentingElement: e,
     });
     await modal.present();

--- a/src/app/get-favorites/get-favorites.component.scss
+++ b/src/app/get-favorites/get-favorites.component.scss
@@ -1,0 +1,13 @@
+.get-favorites-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 2rem 0;
+}
+
+.error-message {
+  display: block;
+  margin: 1rem;
+  color: var(--ion-color-danger);
+  text-align: center;
+}

--- a/src/app/get-favorites/get-favorites.component.scss
+++ b/src/app/get-favorites/get-favorites.component.scss
@@ -1,10 +1,3 @@
-.get-favorites-actions {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  margin: 2rem 0;
-}
-
 .error-message {
   display: block;
   margin: 1rem;

--- a/src/app/get-favorites/get-favorites.component.ts
+++ b/src/app/get-favorites/get-favorites.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit, inject, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, signal, viewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import {
   IonButton,
@@ -12,8 +12,7 @@ import {
   IonToolbar,
   ModalController,
 } from '@ionic/angular/standalone';
-import { addIcons } from 'ionicons';
-import { download } from 'ionicons/icons';
+import { ScanService } from '../scan/scan.service';
 
 export enum GetFavoritesResult {
   confirm = 'confirm',
@@ -28,27 +27,44 @@ export enum GetFavoritesResult {
         <ion-buttons slot="start">
           <ion-button (click)="cancel()">Cancel</ion-button>
         </ion-buttons>
-        <ion-buttons slot="end">
-          <ion-button (click)="confirm()">Apply</ion-button>
-        </ion-buttons>
+        @if (showManualEntry()) {
+          <ion-buttons slot="end">
+            <ion-button (click)="confirm()">Apply</ion-button>
+          </ion-buttons>
+        }
         <ion-title>Get Favorites</ion-title>
       </ion-toolbar>
     </ion-header>
 
-    <ion-content>
-      <ion-item>
-        <ion-label position="stacked">Enter the favorite ID</ion-label>
-        <ion-input
-          #favIdInput
-          type="text"
-          [(ngModel)]="uniqueId"
-          placeholder="e.g., ab459f"
-          maxlength="6"
-          autocapitalize="off"
-          autocorrect="off"
-          spellcheck="false"
-        ></ion-input>
-      </ion-item>
+    <ion-content class="ion-padding">
+      @if (!showManualEntry()) {
+        <div class="get-favorites-actions">
+          <ion-button expand="block" (click)="scanQrCode()">Scan QR code</ion-button>
+          <ion-button expand="block" fill="outline" (click)="enterFavoriteIdManually()">
+            Enter Favorite ID Manually
+          </ion-button>
+        </div>
+      }
+
+      @if (showManualEntry()) {
+        <ion-item>
+          <ion-label position="stacked">Enter the favorite ID</ion-label>
+          <ion-input
+            #favIdInput
+            type="text"
+            [(ngModel)]="uniqueId"
+            placeholder="e.g., ab459f"
+            maxlength="6"
+            autocapitalize="off"
+            autocorrect="off"
+            spellcheck="false"
+          ></ion-input>
+        </ion-item>
+      }
+
+      @if (errorMessage()) {
+        <ion-label class="error-message">{{ errorMessage() }}</ion-label>
+      }
     </ion-content>
   `,
   styleUrls: ['./get-favorites.component.scss'],
@@ -68,17 +84,37 @@ export enum GetFavoritesResult {
 })
 export class GetFavoritesComponent implements OnInit {
   private modalCtrl = inject(ModalController);
-  uniqueId: string = '';
-  favIdInput = viewChild.required<IonInput>('favIdInput');
-
-  constructor() {
-    addIcons({ download });
-  }
+  private scanner = inject(ScanService);
+  uniqueId = '';
+  showManualEntry = signal(false);
+  errorMessage = signal('');
+  favIdInput = viewChild<IonInput>('favIdInput');
 
   ngOnInit() {
+    void this.scanner.prepare();
+  }
+
+  enterFavoriteIdManually() {
+    this.errorMessage.set('');
+    this.showManualEntry.set(true);
     setTimeout(() => {
-      this.favIdInput().setFocus();
-    }, 1000);
+      void this.favIdInput()?.setFocus();
+    });
+  }
+
+  async scanQrCode() {
+    this.errorMessage.set('');
+    const scannedId = await this.scanner.scan();
+    if (!scannedId) {
+      return;
+    }
+
+    const id = this.normalizeId(scannedId);
+    if (!id) {
+      this.errorMessage.set('The QR code does not contain a valid favorite ID.');
+      return;
+    }
+    await this.modalCtrl.dismiss(id, GetFavoritesResult.confirm);
   }
 
   async cancel() {
@@ -86,10 +122,16 @@ export class GetFavoritesComponent implements OnInit {
   }
 
   async confirm() {
-    const id = this.uniqueId?.trim().toLowerCase();
-    if (!id || id.length === 0) {
+    const id = this.normalizeId(this.uniqueId);
+    if (!id) {
+      this.errorMessage.set('Enter a valid six-character favorite ID.');
       return;
     }
     await this.modalCtrl.dismiss(id, GetFavoritesResult.confirm);
+  }
+
+  private normalizeId(value: string): string | undefined {
+    const id = value?.trim().toLowerCase();
+    return /^[a-z0-9]{6}$/.test(id) ? id : undefined;
   }
 }

--- a/src/app/get-favorites/get-favorites.component.ts
+++ b/src/app/get-favorites/get-favorites.component.ts
@@ -37,15 +37,6 @@ export enum GetFavoritesResult {
     </ion-header>
 
     <ion-content class="ion-padding">
-      @if (!showManualEntry()) {
-        <div class="get-favorites-actions">
-          <ion-button expand="block" (click)="scanQrCode()">Scan QR code</ion-button>
-          <ion-button expand="block" fill="outline" (click)="enterFavoriteIdManually()">
-            Enter Favorite ID Manually
-          </ion-button>
-        </div>
-      }
-
       @if (showManualEntry()) {
         <ion-item>
           <ion-label position="stacked">Enter the favorite ID</ion-label>
@@ -85,21 +76,22 @@ export enum GetFavoritesResult {
 export class GetFavoritesComponent implements OnInit {
   private modalCtrl = inject(ModalController);
   private scanner = inject(ScanService);
+  mode: 'scan' | 'manual' = 'manual';
   uniqueId = '';
-  showManualEntry = signal(false);
+  showManualEntry = signal(true);
   errorMessage = signal('');
   favIdInput = viewChild<IonInput>('favIdInput');
 
   ngOnInit() {
     void this.scanner.prepare();
-  }
-
-  enterFavoriteIdManually() {
-    this.errorMessage.set('');
-    this.showManualEntry.set(true);
-    setTimeout(() => {
-      void this.favIdInput()?.setFocus();
-    });
+    if (this.mode === 'scan') {
+      this.showManualEntry.set(false);
+      setTimeout(() => void this.scanQrCode());
+    } else {
+      setTimeout(() => {
+        void this.favIdInput()?.setFocus();
+      }, 1000);
+    }
   }
 
   async scanQrCode() {

--- a/src/app/get-favorites/get-favorites.component.ts
+++ b/src/app/get-favorites/get-favorites.component.ts
@@ -98,6 +98,7 @@ export class GetFavoritesComponent implements OnInit {
     this.errorMessage.set('');
     const scannedId = await this.scanner.scan();
     if (!scannedId) {
+      await this.cancel();
       return;
     }
 

--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -532,6 +532,16 @@ export class HomePage implements OnInit {
           this.home();
           return;
         }
+        case 'partial': {
+          this.vm.downloading = false;
+          this.downloadStatus.set(`Downloading images`);
+          this.ui.presentToast(
+            'Update complete, but a network issue caused the map download to fail',
+            this.toastController,
+          );
+          this.home();
+          return;
+        }
         case 'already-updated': {
           this.ui.presentToast('You have the latest camps, events & art for this event', this.toastController);
           this.vm.downloading = false;

--- a/src/app/intro/intro.page.ts
+++ b/src/app/intro/intro.page.ts
@@ -326,7 +326,7 @@ export class IntroPage {
     document.location.href = '';
   }
 
-  // Returns false with failure
+  // Always returns true: a download failure (typically a network issue) must not prevent the launch
   async preDownload(): Promise<boolean> {
     try {
       if (this.api.hasStarted(this.vm.selected!)) {
@@ -348,17 +348,30 @@ export class IntroPage {
       const result = await this.api.download(this.vm.selected, forceDownload, this.download);
 
       if (result == 'error') {
-        // eslint-disable-next-line no-empty
+        await this.notifyNetworkIssue();
+      } else if (result == 'partial') {
+        await this.notifyNetworkIssue(true);
       }
       // Need to save this otherwise it will think we cant start this event
       this.settingsService.setOffline(this.settingsService.settings.datasetId);
       await this.settingsService.save();
       return true;
+    } catch (err) {
+      // A download failure (typically a network issue) should not prevent the event launching
+      console.error(`Download failed during preDownload, launching anyway`, err);
+      await this.notifyNetworkIssue();
+      return true;
     } finally {
       this.vm.downloading = false;
       this.download.set({ status: '', firstDownload: false });
     }
-    return false;
+  }
+
+  private async notifyNetworkIssue(mapOnly = false) {
+    const message = mapOnly
+      ? 'A network issue caused the map download to fail. The event will open without the latest map.'
+      : 'A network issue caused the download to fail. The event will open with previously downloaded data.';
+    await this.ui.presentToast(message, this.toastController, undefined, 4000);
   }
 
   private async preventAutoStart() {

--- a/src/app/scan/scan.service.ts
+++ b/src/app/scan/scan.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@angular/core';
+import {
+  CapacitorBarcodeScanner,
+  CapacitorBarcodeScannerOptions,
+  CapacitorBarcodeScannerTypeHint,
+} from '@capacitor/barcode-scanner';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ScanService {
+  public async prepare(): Promise<void> {}
+
+  public async scan(): Promise<string | undefined> {
+    try {
+      this.hide();
+      const options: CapacitorBarcodeScannerOptions = {
+        hint: CapacitorBarcodeScannerTypeHint.QR_CODE,
+      };
+      const result = await CapacitorBarcodeScanner.scanBarcode(options);
+      if (result.ScanResult) {
+        this.show();
+        return result.ScanResult;
+      }
+    } catch (error) {
+      console.error(error);
+    }
+    this.show();
+    return undefined;
+  }
+
+  private hide() {
+    // The plugin handles the native scanner presentation.
+  }
+
+  private show() {
+    // The plugin handles restoring the native scanner presentation.
+  }
+}

--- a/src/app/share-favorites/share-favorites.component.scss
+++ b/src/app/share-favorites/share-favorites.component.scss
@@ -12,6 +12,15 @@ ion-spinner {
   height: 3rem;
 }
 
+.favorite-qr {
+  width: 240px;
+  height: 240px;
+  max-width: 80vw;
+  max-height: 80vw;
+  margin-bottom: 1rem;
+  background: white;
+}
+
 .favorite-id {
   font-size: 3rem;
   font-weight: bold;

--- a/src/app/share-favorites/share-favorites.component.scss
+++ b/src/app/share-favorites/share-favorites.component.scss
@@ -29,6 +29,15 @@ ion-spinner {
   color: var(--ion-color-primary);
 }
 
+.favorite-info {
+  max-width: 28rem;
+  margin-top: 1.5rem;
+  color: var(--ion-color-medium-shade);
+  font-size: 1rem;
+  line-height: 1.5;
+  text-align: center;
+}
+
 .share-message {
   font-size: 1.5rem;
   font-weight: bold;

--- a/src/app/share-favorites/share-favorites.component.ts
+++ b/src/app/share-favorites/share-favorites.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, effect, inject, signal, viewChild } from '@angular/core';
 import {
   IonButton,
   IonButtons,
@@ -15,6 +15,7 @@ import { Network } from '@capacitor/network';
 import { addIcons } from 'ionicons';
 import { shareOutline } from 'ionicons/icons';
 import { FavoritesService } from '../favs/favorites.service';
+import QRCode from 'qrcode';
 
 export type ShareStatus = 'loading' | 'success' | 'failed' | 'no-network';
 
@@ -43,6 +44,7 @@ export type ShareStatus = 'loading' | 'success' | 'failed' | 'no-network';
           <ion-spinner name="crescent"></ion-spinner>
         }
         @if (status() === 'success') {
+          <canvas #qrCode class="favorite-qr" aria-label="QR code for your favorite ID"></canvas>
           <div class="favorite-id">{{ uniqueId() }}</div>
         }
         @if (status() === 'failed') {
@@ -56,16 +58,7 @@ export type ShareStatus = 'loading' | 'success' | 'failed' | 'no-network';
   `,
   styleUrls: ['./share-favorites.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [
-    IonButton,
-    IonButtons,
-    IonContent,
-    IonHeader,
-    IonIcon,
-    IonSpinner,
-    IonTitle,
-    IonToolbar,
-  ],
+  imports: [IonButton, IonButtons, IonContent, IonHeader, IonIcon, IonSpinner, IonTitle, IonToolbar],
 })
 export class ShareFavoritesComponent {
   private modalCtrl = inject(ModalController);
@@ -73,9 +66,17 @@ export class ShareFavoritesComponent {
 
   status = signal<ShareStatus>('loading');
   uniqueId = signal<string>('');
+  private qrCode = viewChild<ElementRef<HTMLCanvasElement>>('qrCode');
 
   constructor() {
     addIcons({ shareOutline });
+    effect(() => {
+      const id = this.uniqueId();
+      const canvas = this.qrCode()?.nativeElement;
+      if (id && canvas) {
+        void QRCode.toCanvas(canvas, id, { width: 240, margin: 2 });
+      }
+    });
     this.start();
   }
 

--- a/src/app/share-favorites/share-favorites.component.ts
+++ b/src/app/share-favorites/share-favorites.component.ts
@@ -46,6 +46,7 @@ export type ShareStatus = 'loading' | 'success' | 'failed' | 'no-network';
         @if (status() === 'success') {
           <canvas #qrCode class="favorite-qr" aria-label="QR code for your favorite ID"></canvas>
           <div class="favorite-id">{{ uniqueId() }}</div>
+          <div class="favorite-info">{{ favoriteInfo() }}</div>
         }
         @if (status() === 'failed') {
           <div class="share-message failed">Failed to Share</div>
@@ -66,6 +67,7 @@ export class ShareFavoritesComponent {
 
   status = signal<ShareStatus>('loading');
   uniqueId = signal<string>('');
+  favoriteInfo = signal('');
   private qrCode = viewChild<ElementRef<HTMLCanvasElement>>('qrCode');
 
   constructor() {
@@ -87,7 +89,15 @@ export class ShareFavoritesComponent {
         this.status.set('no-network');
         return;
       }
+      const favorites = await this.fav.getFavorites();
       const id = await this.fav.shareFavorites();
+      const eventCount = favorites.events.length + favorites.rslEvents.length;
+      const campAndArtCount = favorites.camps.length + favorites.art.length;
+      this.favoriteInfo.set(
+        eventCount === 0 && campAndArtCount === 0
+          ? 'You have not favorited any events, camps or art'
+          : `On another phone choose “Scan Favorites” and point to this QR code, or choose “Enter ID” and type in this ID to download these ${eventCount} events, ${campAndArtCount} favorite camps & art`,
+      );
       this.uniqueId.set(id);
       this.status.set('success');
     } catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import {
+  ApplicationConfig,
   provideAppInitializer,
   enableProdMode,
   inject,
@@ -20,6 +21,7 @@ import { provideServiceWorker } from '@angular/service-worker';
 import { Capacitor } from '@capacitor/core';
 
 import { routes } from './app/app.routes';
+import { showWebViewUpdateScreen, webViewTooOld } from './webview-check';
 import { AppComponent } from './app/app.component';
 import { environment } from './environments/environment';
 import { DbService } from './app/data/db.service';
@@ -47,7 +49,7 @@ function shouldEnableServiceWorker(): boolean {
   return shouldEnable;
 }
 
-bootstrapApplication(AppComponent, {
+const appConfig: ApplicationConfig = {
   providers: [
     provideAnimations(),
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
@@ -84,4 +86,10 @@ bootstrapApplication(AppComponent, {
       registrationStrategy: 'registerWhenStable:30000',
     }),
   ],
-});
+};
+
+if (webViewTooOld()) {
+  showWebViewUpdateScreen();
+} else {
+  bootstrapApplication(AppComponent, appConfig);
+}

--- a/src/webview-check.ts
+++ b/src/webview-check.ts
@@ -1,0 +1,66 @@
+/**
+ * Deliberately free of framework and Capacitor dependencies: this runs before
+ * Angular bootstraps and must render on WebView versions too old to run the
+ * app, so it is plain DOM only.
+ */
+
+/**
+ * Angular's runtime calls `Object.hasOwn` (ES2022), which does not exist in
+ * Android System WebView builds older than Chrome 93. On those devices the
+ * app crashes during the first change detection pass of the intro page and
+ * appears frozen.
+ */
+export function webViewTooOld(): boolean {
+  if (!/Android/.test(navigator.userAgent)) {
+    return false;
+  }
+  return typeof Object.hasOwn !== 'function';
+}
+
+/**
+ * Renders a blocking, plain-DOM message telling the user to update Android
+ * System WebView (the WebView provider on Android 10+) or Chrome (the
+ * provider on Android 7-9) from the Play Store.
+ */
+export function showWebViewUpdateScreen(): void {
+  const overlay = document.createElement('div');
+  overlay.setAttribute('role', 'alertdialog');
+  overlay.style.cssText = [
+    'position:fixed',
+    'inset:0',
+    'z-index:99999',
+    'display:flex',
+    'flex-direction:column',
+    'align-items:center',
+    'justify-content:center',
+    'padding:32px 24px',
+    'box-sizing:border-box',
+    'background:#1a1b1e',
+    'color:#ffffff',
+    'font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif',
+  ].join(';');
+
+  const heading = document.createElement('h1');
+  heading.textContent = 'Update required';
+  heading.style.cssText = 'margin:0 0 16px;font-size:24px;text-align:center';
+
+  const message = document.createElement('p');
+  message.textContent = 'dust cannot run on this device because its Android System WebView is out of date.';
+  message.style.cssText = 'margin:0 0 16px;max-width:420px;line-height:1.5;font-size:16px;text-align:center';
+
+  const steps = document.createElement('ol');
+  steps.style.cssText = 'margin:0;max-width:420px;line-height:2;font-size:16px;padding-left:24px';
+  for (const step of [
+    'Open the Play Store app.',
+    'Search for "Android System WebView" (published by Google LLC).',
+    'Tap Update. If no update is offered, update the Chrome app the same way.',
+    'Reopen dust.',
+  ]) {
+    const item = document.createElement('li');
+    item.textContent = step;
+    steps.appendChild(item);
+  }
+
+  overlay.append(heading, message, steps);
+  document.body.appendChild(overlay);
+}


### PR DESCRIPTION
## Changes
- Add `@capacitor/barcode-scanner` to the Android Capacitor configuration.
- Add `qrcode` and `@types/qrcode` dependencies.
- Include the barcode scanner’s `html5-qrcode` dependency through the lockfile.
- Increase the Android minimum SDK version from 23 to 26.

## Context
These changes add the dependencies and Android configuration required to support barcode and QR code scanning.